### PR TITLE
Add wait_for_single_object

### DIFF
--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -369,38 +369,19 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
     return term
 
 
-def wait_for_single_object(handle, timeout_ms):
-    """
-    Args:
-        handle(int): Windows handle object as returned by :py:func:`msvcrt.get_osfhandle`
-        timeout_ms(int): Timeout in milliseconds, or INFINITE for no timeout
-
-    Returns:
-        int: WAIT_OBJECT_0 if signaled, WAIT_TIMEOUT if timed out, or other wait result
-
-    Wrapper for WaitForSingleObject_
-
-    .. _WaitForSingleObject:
-        https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
-    """
-
-    return KERNEL32.WaitForSingleObject(handle, timeout_ms)
-
-
 def kbhit(fd=None, timeout=None):
     """
     Args:
         fd(int): Python file descriptor for keyboard input (e.g., sys.stdin.fileno()).
-            If None, only uses msvcrt.kbhit() without efficient waiting.
+            If None, uses the file descriptor of :py:data:`sys.__stdin__`.
         timeout(float): Timeout in seconds. None for blocking indefinitely,
             0 for non-blocking, positive number for timeout in seconds.
 
     Returns:
         bool: True if a keypress is available to be read, False otherwise.
 
-    Efficient keyboard hit detection using WaitForSingleObject.
+    A more efficient kbhit() using WaitForSingleObject.
 
-    This function provides Windows-compatible select()-like behavior for console input.
     Instead of busy-polling with sleep(), it uses WaitForSingleObject to efficiently
     wait for keyboard input, significantly reducing CPU usage.
 
@@ -425,9 +406,9 @@ def kbhit(fd=None, timeout=None):
     if msvcrt.kbhit():
         return True
 
-    # If no fd provided, can only do polling fallback
+    # If no fd provided, use __stdin__
     if fd is None:
-        return _kbhit_poll(timeout)
+        fd = sys.__stdin__.fileno()
 
     # Get the console input handle for WaitForSingleObject
     handle = msvcrt.get_osfhandle(fd)
@@ -440,30 +421,8 @@ def kbhit(fd=None, timeout=None):
     else:
         wait_ms = int(timeout * 1000)
 
-    # Efficient wait using Windows API (like select() on Unix)
-    result = wait_for_single_object(handle, wait_ms)
+    # Efficient wait using Windows API
+    result = KERNEL32.WaitForSingleObject(handle, wait_ms)
     if result == WAIT_OBJECT_0:
         return msvcrt.kbhit()  # Double-check after wait
-    return False
-
-
-def _kbhit_poll(timeout):
-    """
-    Fallback polling implementation for kbhit when fd is not available.
-
-    Args:
-        timeout(float): Timeout in seconds.
-
-    Returns:
-        bool: True if a keypress is available, False otherwise.
-    """
-    import time
-
-    end = time.time() + (timeout or 0)
-    while True:
-        if msvcrt.kbhit():
-            return True
-        if timeout is not None and end < time.time():
-            break
-        time.sleep(0.001)
     return False

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -385,3 +385,85 @@ def wait_for_single_object(handle, timeout_ms):
     """
 
     return KERNEL32.WaitForSingleObject(handle, timeout_ms)
+
+
+def kbhit(fd=None, timeout=None):
+    """
+    Args:
+        fd(int): Python file descriptor for keyboard input (e.g., sys.stdin.fileno()).
+            If None, only uses msvcrt.kbhit() without efficient waiting.
+        timeout(float): Timeout in seconds. None for blocking indefinitely,
+            0 for non-blocking, positive number for timeout in seconds.
+
+    Returns:
+        bool: True if a keypress is available to be read, False otherwise.
+
+    Efficient keyboard hit detection using WaitForSingleObject.
+
+    This function provides Windows-compatible select()-like behavior for console input.
+    Instead of busy-polling with sleep(), it uses WaitForSingleObject to efficiently
+    wait for keyboard input, significantly reducing CPU usage.
+
+    Example usage::
+
+        import sys
+        from jinxed import win32
+
+        # Non-blocking check
+        if win32.kbhit(sys.stdin.fileno(), timeout=0):
+            char = msvcrt.getwch()
+
+        # Wait up to 5 seconds for input
+        if win32.kbhit(sys.stdin.fileno(), timeout=5.0):
+            char = msvcrt.getwch()
+
+        # Block indefinitely until input
+        if win32.kbhit(sys.stdin.fileno(), timeout=None):
+            char = msvcrt.getwch()
+    """
+    # Quick check first - if data is already available, return immediately
+    if msvcrt.kbhit():
+        return True
+
+    # If no fd provided, can only do polling fallback
+    if fd is None:
+        return _kbhit_poll(timeout)
+
+    # Get the console input handle for WaitForSingleObject
+    handle = msvcrt.get_osfhandle(fd)
+
+    # Convert timeout to milliseconds for Windows API
+    if timeout is None:
+        wait_ms = INFINITE
+    elif timeout <= 0:
+        return False  # Non-blocking, already checked above
+    else:
+        wait_ms = int(timeout * 1000)
+
+    # Efficient wait using Windows API (like select() on Unix)
+    result = wait_for_single_object(handle, wait_ms)
+    if result == WAIT_OBJECT_0:
+        return msvcrt.kbhit()  # Double-check after wait
+    return False
+
+
+def _kbhit_poll(timeout):
+    """
+    Fallback polling implementation for kbhit when fd is not available.
+
+    Args:
+        timeout(float): Timeout in seconds.
+
+    Returns:
+        bool: True if a keypress is available, False otherwise.
+    """
+    import time
+
+    end = time.time() + (timeout or 0)
+    while True:
+        if msvcrt.kbhit():
+            return True
+        if timeout is not None and end < time.time():
+            break
+        time.sleep(0.001)
+    return False

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -47,6 +47,11 @@ ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 DISABLE_NEWLINE_AUTO_RETURN = 0x0008
 ENABLE_LVB_GRID_WORLDWIDE = 0x0010
 
+# WaitForSingleObject return values and constants
+WAIT_OBJECT_0 = 0x00000000
+WAIT_TIMEOUT = 0x00000102
+INFINITE = 0xFFFFFFFF
+
 if IS_WINDOWS and tuple(int(num) for num in platform.version().split('.')) >= (10, 0, 10586):
     VTMODE_SUPPORTED = True
     CBREAK_MODE = ENABLE_PROCESSED_INPUT | ENABLE_VIRTUAL_TERMINAL_INPUT
@@ -100,6 +105,9 @@ KERNEL32.SetConsoleMode.argtypes = (wintypes.HANDLE, wintypes.DWORD)
 
 KERNEL32.GetConsoleScreenBufferInfo.errcheck = _check_bool
 KERNEL32.GetConsoleScreenBufferInfo.argtypes = (wintypes.HANDLE, CSBIP)
+
+KERNEL32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+KERNEL32.WaitForSingleObject.restype = wintypes.DWORD
 
 
 def get_csbi(filehandle=None):
@@ -359,3 +367,21 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
             term = 'unknown'
 
     return term
+
+
+def wait_for_single_object(handle, timeout_ms):
+    """
+    Args:
+        handle(int): Windows handle object as returned by :py:func:`msvcrt.get_osfhandle`
+        timeout_ms(int): Timeout in milliseconds, or INFINITE for no timeout
+
+    Returns:
+        int: WAIT_OBJECT_0 if signaled, WAIT_TIMEOUT if timed out, or other wait result
+
+    Wrapper for WaitForSingleObject_
+
+    .. _WaitForSingleObject:
+        https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
+    """
+
+    return KERNEL32.WaitForSingleObject(handle, timeout_ms)


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Expose a wait_for_single_object helper wrapping the Win32 WaitForSingleObject call with timeout support.