### PR TITLE
Wait for single object (round 2)

### DIFF
--- a/jinxed/__init__.py
+++ b/jinxed/__init__.py
@@ -27,7 +27,7 @@ else:
     from jinxed._util import get_term
 
 
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 
 COLOR_BLACK = 0
 COLOR_RED = 1

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -411,7 +411,8 @@ def kbhit(fd=None, timeout=None):
 
     result = KERNEL32.WaitForSingleObject(
         msvcrt.get_osfhandle(fd),
-        0xFFFFFFFF if timeout is None else int(1000 * max(0, timeout)),
+        0xFFFFFFFF if timeout is None  # INFINITE
+        else int(1000 * max(0, timeout)),
     )
 
     if result == 0xFFFFFFFF:  # WAIT_FAILED

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -370,13 +370,12 @@ def kbhit(fd=None, timeout=None):
         fd(int): Python file descriptor for keyboard input (e.g., sys.stdin.fileno()).
             If None, uses the file descriptor of :py:data:`sys.__stdin__`.
         timeout(float): Timeout in seconds. None for blocking indefinitely,
-            0 for non-blocking, positive number for timeout in seconds.
+            0 for non-blocking, in seconds, negative timeout is clipped to 0.
 
     Returns:
         bool: True if a keypress is available to be read, False otherwise.
 
     Raises:
-        ValueError: If timeout is negative
         OSError: If WaitForSingleObject fails
 
     Efficient keyboard hit detection using WaitForSingleObject_.

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -369,38 +369,19 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
     return term
 
 
-def wait_for_single_object(handle, timeout_ms):
-    """
-    Args:
-        handle(int): Windows handle object as returned by :py:func:`msvcrt.get_osfhandle`
-        timeout_ms(int): Timeout in milliseconds, or INFINITE for no timeout
-
-    Returns:
-        int: WAIT_OBJECT_0 if signaled, WAIT_TIMEOUT if timed out, or other wait result
-
-    Wrapper for WaitForSingleObject_
-
-    .. _WaitForSingleObject:
-        https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
-    """
-
-    return KERNEL32.WaitForSingleObject(handle, timeout_ms)
-
-
 def kbhit(fd=None, timeout=None):
     """
     Args:
         fd(int): Python file descriptor for keyboard input (e.g., sys.stdin.fileno()).
-            If None, only uses msvcrt.kbhit() without efficient waiting.
+            If None, uses the file descriptor of :py:data:`sys.__stdin__`.
         timeout(float): Timeout in seconds. None for blocking indefinitely,
             0 for non-blocking, positive number for timeout in seconds.
 
     Returns:
         bool: True if a keypress is available to be read, False otherwise.
 
-    Efficient keyboard hit detection using WaitForSingleObject.
+    A more efficient kbhit() using WaitForSingleObject.
 
-    This function provides Windows-compatible select()-like behavior for console input.
     Instead of busy-polling with sleep(), it uses WaitForSingleObject to efficiently
     wait for keyboard input, significantly reducing CPU usage.
 
@@ -425,9 +406,9 @@ def kbhit(fd=None, timeout=None):
     if msvcrt.kbhit():
         return True
 
-    # If no fd provided, can only do polling fallback
+    # If no fd provided, use __stdin__
     if fd is None:
-        return _kbhit_poll(timeout)
+        fd = sys.__stdin__.fileno()
 
     # Get the console input handle for WaitForSingleObject
     handle = msvcrt.get_osfhandle(fd)
@@ -440,30 +421,8 @@ def kbhit(fd=None, timeout=None):
     else:
         wait_ms = int(timeout * 1000)
 
-    # Efficient wait using Windows API (like select() on Unix)
-    result = wait_for_single_object(handle, wait_ms)
+    # Efficient wait using Windows API
+    result = KERNEL32.WaitForSingleObject(handle, wait_ms)
     if result == WAIT_OBJECT_0:
         return msvcrt.kbhit()  # Double-check after wait
-    return False
-
-
-def _kbhit_poll(timeout):
-    """
-    Fallback polling implementation for kbhit when fd is not available.
-
-    Args:
-        timeout(float): Timeout in seconds.
-
-    Returns:
-        bool: True if a keypress is available, False otherwise.
-    """
-    import time
-
-    end = time.time() + (timeout or 0)
-    while True:
-        if msvcrt.kbhit():
-            return True
-        if timeout is not None and end < time.time():
-            break
-        time.sleep(0.001)
     return False

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -410,15 +410,9 @@ def kbhit(fd=None, timeout=None):
     if fd is None:
         fd = sys.__stdin__.fileno()
 
-    if timeout is not None and timeout < 0:
-        raise ValueError('timeout must be non-negative')
-
-    if timeout is not None and timeout <= 0:
-        return False
-
     result = KERNEL32.WaitForSingleObject(
         msvcrt.get_osfhandle(fd),
-        0xFFFFFFFF if timeout is None else int(1000 * timeout),
+        0xFFFFFFFF if timeout is None else int(1000 * max(0, timeout)),
     )
 
     if result == 0xFFFFFFFF:  # WAIT_FAILED

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# pylint: disable=too-few-public-methods
 """
 Support functions and wrappers for calls to the Windows API
 """
@@ -19,6 +20,7 @@ import msvcrt  # pylint: disable=import-error
 import os
 import platform
 import sys
+import time
 
 from jinxed._util import mock, IS_WINDOWS
 
@@ -59,8 +61,7 @@ else:
 GTS_SUPPORTED = hasattr(os, 'get_terminal_size')
 TerminalSize = namedtuple('TerminalSize', ('columns', 'lines'))
 
-
-class ConsoleScreenBufferInfo(ctypes.Structure):  # pylint: disable=too-few-public-methods
+class ConsoleScreenBufferInfo(ctypes.Structure):
     """
     Python representation of CONSOLE_SCREEN_BUFFER_INFO structure
     https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str
@@ -103,6 +104,49 @@ KERNEL32.GetConsoleScreenBufferInfo.argtypes = (wintypes.HANDLE, CSBIP)
 
 KERNEL32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
 KERNEL32.WaitForSingleObject.restype = wintypes.DWORD
+
+# Console input record structures for PeekConsoleInputW/ReadConsoleInputW.
+# Only KEY_EVENT_RECORD is needed -- all other event types (mouse, focus,
+# resize, menu) are drained and discarded by kbhit() for now.
+
+
+class _KEY_EVENT_RECORD(ctypes.Structure):
+    """KEY_EVENT_RECORD -- 16 bytes, the largest INPUT_RECORD union member."""
+
+    _fields_ = [
+        ('bKeyDown', wintypes.BOOL),
+        ('wRepeatCount', wintypes.WORD),
+        ('wVirtualKeyCode', wintypes.WORD),
+        ('wVirtualScanCode', wintypes.WORD),
+        ('uChar', wintypes.WCHAR),
+        ('dwControlKeyState', wintypes.DWORD),
+    ]
+
+
+class _EVENT_UNION(ctypes.Union):
+    """INPUT_RECORD Event union (only KeyEvent is accessed)."""
+
+    _fields_ = [('KeyEvent', _KEY_EVENT_RECORD)]
+
+
+class _INPUT_RECORD(ctypes.Structure):
+    """INPUT_RECORD structure."""
+
+    _fields_ = [
+        ('EventType', wintypes.WORD),
+        ('Event', _EVENT_UNION),
+    ]
+
+
+_PINPUT_RECORD = ctypes.POINTER(_INPUT_RECORD)
+
+KERNEL32.PeekConsoleInputW.argtypes = (
+    wintypes.HANDLE, _PINPUT_RECORD, wintypes.DWORD, LPDWORD)
+KERNEL32.PeekConsoleInputW.restype = wintypes.BOOL
+
+KERNEL32.ReadConsoleInputW.argtypes = (
+    wintypes.HANDLE, _PINPUT_RECORD, wintypes.DWORD, LPDWORD)
+KERNEL32.ReadConsoleInputW.restype = wintypes.BOOL
 
 
 def get_csbi(filehandle=None):
@@ -364,13 +408,37 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
     return term
 
 
+def _drain_nonkey_events(handle):
+    """
+    Discard non-key-down events from the console input buffer.
+
+    :arg int handle: Windows console handle.
+    :returns: True if a key-down event is at the front of the buffer.
+    :rtype: bool
+    """
+    record = _INPUT_RECORD()
+    count = wintypes.DWORD()
+    while True:
+        if not KERNEL32.PeekConsoleInputW(
+                handle, ctypes.byref(record), 1, ctypes.byref(count)):
+            return False
+        if count.value == 0:
+            return False
+        if record.EventType == 0x0001 and record.Event.KeyEvent.bKeyDown:
+            return True  # KEY_EVENT with bKeyDown
+        # discard non-key-down event (key-up, focus, mouse, resize, menu)
+        if not KERNEL32.ReadConsoleInputW(
+                handle, ctypes.byref(record), 1, ctypes.byref(count)):
+            return False
+
+
 def kbhit(fd=None, timeout=None):
     """
     Args:
         fd(int): Python file descriptor for keyboard input (e.g., sys.stdin.fileno()).
             If None, uses the file descriptor of :py:data:`sys.__stdin__`.
         timeout(float): Timeout in seconds. None for blocking indefinitely,
-            0 for non-blocking, in seconds, negative timeout is clipped to 0.
+            0 for non-blocking, positive for seconds to wait.
 
     Returns:
         bool: True if a keypress is available to be read, False otherwise.
@@ -380,42 +448,37 @@ def kbhit(fd=None, timeout=None):
 
     Efficient keyboard hit detection using WaitForSingleObject_.
 
-    Instead of busy-polling with sleep(), uses WaitForSingleObject to efficiently
-    wait for keyboard input, significantly reducing CPU usage.
-
-    Supported on Windows XP / Windows Server 2003 or above.
-
-    Example usage::
-
-        import sys
-        from jinxed import win32
-
-        # Non-blocking check
-        if win32.kbhit(sys.stdin.fileno(), timeout=0):
-            char = msvcrt.getwch()
-
-        # Wait up to 5 seconds for input
-        if win32.kbhit(sys.stdin.fileno(), timeout=5.0):
-            char = msvcrt.getwch()
-
-        # Block indefinitely until input
-        if win32.kbhit(sys.stdin.fileno(), timeout=None):
-            char = msvcrt.getwch()
+    After the wait signals, non-keyboard events (key-up releases, focus,
+    resize) are drained from the input buffer so that only actual key-down
+    events cause a True return.
 
     .. _WaitForSingleObject:
         https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
     """
-
     if fd is None:
         fd = sys.__stdin__.fileno()
 
-    result = KERNEL32.WaitForSingleObject(
-        msvcrt.get_osfhandle(fd),
-        0xFFFFFFFF if timeout is None  # INFINITE
-        else int(1000 * max(0, timeout)),
-    )
+    handle = msvcrt.get_osfhandle(fd)
+    deadline = None if timeout is None else time.monotonic() + max(0, timeout)
 
-    if result == 0xFFFFFFFF:  # WAIT_FAILED
-        raise ctypes.WinError(ctypes.get_last_error())
+    while True:
+        # Drain stale non-key events, return immediately if key-down ready.
+        if _drain_nonkey_events(handle):
+            return True
 
-    return result == 0x00000000  # WAIT_OBJECT_0
+        # Calculate remaining wait.
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            wait_ms = int(1000 * remaining)
+        else:
+            wait_ms = 0xFFFFFFFF  # INFINITE
+
+        result = KERNEL32.WaitForSingleObject(handle, wait_ms)
+
+        if result == 0xFFFFFFFF:  # WAIT_FAILED
+            raise ctypes.WinError(ctypes.get_last_error())
+
+        if result != 0x00000000:  # WAIT_TIMEOUT
+            return False

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -385,3 +385,85 @@ def wait_for_single_object(handle, timeout_ms):
     """
 
     return KERNEL32.WaitForSingleObject(handle, timeout_ms)
+
+
+def kbhit(fd=None, timeout=None):
+    """
+    Args:
+        fd(int): Python file descriptor for keyboard input (e.g., sys.stdin.fileno()).
+            If None, only uses msvcrt.kbhit() without efficient waiting.
+        timeout(float): Timeout in seconds. None for blocking indefinitely,
+            0 for non-blocking, positive number for timeout in seconds.
+
+    Returns:
+        bool: True if a keypress is available to be read, False otherwise.
+
+    Efficient keyboard hit detection using WaitForSingleObject.
+
+    This function provides Windows-compatible select()-like behavior for console input.
+    Instead of busy-polling with sleep(), it uses WaitForSingleObject to efficiently
+    wait for keyboard input, significantly reducing CPU usage.
+
+    Example usage::
+
+        import sys
+        from jinxed import win32
+
+        # Non-blocking check
+        if win32.kbhit(sys.stdin.fileno(), timeout=0):
+            char = msvcrt.getwch()
+
+        # Wait up to 5 seconds for input
+        if win32.kbhit(sys.stdin.fileno(), timeout=5.0):
+            char = msvcrt.getwch()
+
+        # Block indefinitely until input
+        if win32.kbhit(sys.stdin.fileno(), timeout=None):
+            char = msvcrt.getwch()
+    """
+    # Quick check first - if data is already available, return immediately
+    if msvcrt.kbhit():
+        return True
+
+    # If no fd provided, can only do polling fallback
+    if fd is None:
+        return _kbhit_poll(timeout)
+
+    # Get the console input handle for WaitForSingleObject
+    handle = msvcrt.get_osfhandle(fd)
+
+    # Convert timeout to milliseconds for Windows API
+    if timeout is None:
+        wait_ms = INFINITE
+    elif timeout <= 0:
+        return False  # Non-blocking, already checked above
+    else:
+        wait_ms = int(timeout * 1000)
+
+    # Efficient wait using Windows API (like select() on Unix)
+    result = wait_for_single_object(handle, wait_ms)
+    if result == WAIT_OBJECT_0:
+        return msvcrt.kbhit()  # Double-check after wait
+    return False
+
+
+def _kbhit_poll(timeout):
+    """
+    Fallback polling implementation for kbhit when fd is not available.
+
+    Args:
+        timeout(float): Timeout in seconds.
+
+    Returns:
+        bool: True if a keypress is available, False otherwise.
+    """
+    import time
+
+    end = time.time() + (timeout or 0)
+    while True:
+        if msvcrt.kbhit():
+            return True
+        if timeout is not None and end < time.time():
+            break
+        time.sleep(0.001)
+    return False

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -47,11 +47,6 @@ ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 DISABLE_NEWLINE_AUTO_RETURN = 0x0008
 ENABLE_LVB_GRID_WORLDWIDE = 0x0010
 
-# WaitForSingleObject return values and constants
-WAIT_OBJECT_0 = 0x00000000
-WAIT_TIMEOUT = 0x00000102
-INFINITE = 0xFFFFFFFF
-
 if IS_WINDOWS and tuple(int(num) for num in platform.version().split('.')) >= (10, 0, 10586):
     VTMODE_SUPPORTED = True
     CBREAK_MODE = ENABLE_PROCESSED_INPUT | ENABLE_VIRTUAL_TERMINAL_INPUT
@@ -380,10 +375,16 @@ def kbhit(fd=None, timeout=None):
     Returns:
         bool: True if a keypress is available to be read, False otherwise.
 
-    A more efficient kbhit() using WaitForSingleObject.
+    Raises:
+        ValueError: If timeout is negative
+        OSError: If WaitForSingleObject fails
 
-    Instead of busy-polling with sleep(), it uses WaitForSingleObject to efficiently
+    Efficient keyboard hit detection using WaitForSingleObject_.
+
+    Instead of busy-polling with sleep(), uses WaitForSingleObject to efficiently
     wait for keyboard input, significantly reducing CPU usage.
+
+    Supported on Windows XP / Windows Server 2003 or above.
 
     Example usage::
 
@@ -401,28 +402,26 @@ def kbhit(fd=None, timeout=None):
         # Block indefinitely until input
         if win32.kbhit(sys.stdin.fileno(), timeout=None):
             char = msvcrt.getwch()
-    """
-    # Quick check first - if data is already available, return immediately
-    if msvcrt.kbhit():
-        return True
 
-    # If no fd provided, use __stdin__
+    .. _WaitForSingleObject:
+        https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
+    """
+
     if fd is None:
         fd = sys.__stdin__.fileno()
 
-    # Get the console input handle for WaitForSingleObject
-    handle = msvcrt.get_osfhandle(fd)
+    if timeout is not None and timeout < 0:
+        raise ValueError('timeout must be non-negative')
 
-    # Convert timeout to milliseconds for Windows API
-    if timeout is None:
-        wait_ms = INFINITE
-    elif timeout <= 0:
-        return False  # Non-blocking, already checked above
-    else:
-        wait_ms = int(timeout * 1000)
+    if timeout is not None and timeout <= 0:
+        return False
 
-    # Efficient wait using Windows API
-    result = KERNEL32.WaitForSingleObject(handle, wait_ms)
-    if result == WAIT_OBJECT_0:
-        return msvcrt.kbhit()  # Double-check after wait
-    return False
+    result = KERNEL32.WaitForSingleObject(
+        msvcrt.get_osfhandle(fd),
+        0xFFFFFFFF if timeout is None else int(1000 * timeout),
+    )
+
+    if result == 0xFFFFFFFF:  # WAIT_FAILED
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    return result == 0x00000000  # WAIT_OBJECT_0

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -20,7 +20,6 @@ import msvcrt  # pylint: disable=import-error
 import os
 import platform
 import sys
-import time
 
 from jinxed._util import mock, IS_WINDOWS
 
@@ -61,10 +60,11 @@ else:
 GTS_SUPPORTED = hasattr(os, 'get_terminal_size')
 TerminalSize = namedtuple('TerminalSize', ('columns', 'lines'))
 
+
 class ConsoleScreenBufferInfo(ctypes.Structure):
     """
     Python representation of CONSOLE_SCREEN_BUFFER_INFO structure
-    https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str
+    https://learn.microsoft.com/en-us/windows/console/console-screen-buffer-info-str
     """
 
     _fields_ = [('dwSize', COORD),
@@ -109,7 +109,7 @@ KERNEL32.WaitForSingleObject.restype = wintypes.DWORD
 
 
 class _KEY_EVENT_RECORD(ctypes.Structure):
-    """KEY_EVENT_RECORD -- 16 bytes, the largest INPUT_RECORD union member."""
+    """KEY_EVENT_RECORD structure."""
 
     _fields_ = [
         ('bKeyDown', wintypes.BOOL),
@@ -121,13 +121,34 @@ class _KEY_EVENT_RECORD(ctypes.Structure):
     ]
 
 
-class _EVENT_UNION(ctypes.Union):
-    """INPUT_RECORD Event union (only KeyEvent is accessed)."""
+class _MOUSE_EVENT_RECORD(ctypes.Structure):
+    """MOUSE_EVENT_RECORD structure."""
 
-    _fields_ = [('KeyEvent', _KEY_EVENT_RECORD)]
+    _fields_ = [
+        ('dwMousePosition', COORD),
+        ('dwButtonState', wintypes.DWORD),
+        ('dwControlKeyState', wintypes.DWORD),
+        ('dwEventFlags', wintypes.DWORD),
+    ]
 
 
-class _INPUT_RECORD(ctypes.Structure):
+class _WINDOW_BUFFER_SIZE_RECORD(ctypes.Structure):
+    """WINDOW_BUFFER_SIZE_RECORD structure."""
+
+    _fields_ = [('dwSize', COORD)]
+
+
+class _INPUT_RECORD_EVENT(ctypes.Union):
+    """Union of console input event types."""
+
+    _fields_ = [
+        ('KeyEvent', _KEY_EVENT_RECORD),
+        ('MouseEvent', _MOUSE_EVENT_RECORD),
+        ('WindowBufferSizeEvent', _WINDOW_BUFFER_SIZE_RECORD),
+    ]
+
+
+class INPUT_RECORD(ctypes.Structure):
     """INPUT_RECORD structure.
 
     .. py:attribute:: EventType
@@ -137,35 +158,35 @@ class _INPUT_RECORD(ctypes.Structure):
         - ``0x0001`` -- KEY_EVENT
         - ``0x0002`` -- MOUSE_EVENT
         - ``0x0004`` -- WINDOW_BUFFER_SIZE_EVENT
-        - ``0x0008`` -- MENU_EVENT
-        - ``0x0010`` -- FOCUS_EVENT
 
     .. py:attribute:: Event
 
-        Union containing the event data. Access ``Event.KeyEvent``
-        for key events.
+        Union of event data.  Access the member matching ``EventType``:
+
+        - ``Event.KeyEvent`` -- ``bKeyDown``, ``wRepeatCount``,
+          ``wVirtualKeyCode``, ``wVirtualScanCode``, ``uChar``,
+          ``dwControlKeyState``
+        - ``Event.MouseEvent`` -- ``dwMousePosition``, ``dwButtonState``,
+          ``dwControlKeyState``, ``dwEventFlags``
+        - ``Event.WindowBufferSizeEvent`` -- ``dwSize``
     """
 
     _fields_ = [
         ('EventType', wintypes.WORD),
-        ('Event', _EVENT_UNION),
+        ('Event', _INPUT_RECORD_EVENT),
     ]
 
-
-_PINPUT_RECORD = ctypes.POINTER(_INPUT_RECORD)
 
 KEY_EVENT = 0x0001
 MOUSE_EVENT = 0x0002
 WINDOW_BUFFER_SIZE_EVENT = 0x0004
-MENU_EVENT = 0x0008
-FOCUS_EVENT = 0x0010
 
 KERNEL32.PeekConsoleInputW.argtypes = (
-    wintypes.HANDLE, _PINPUT_RECORD, wintypes.DWORD, LPDWORD)
+    wintypes.HANDLE, ctypes.POINTER(INPUT_RECORD), wintypes.DWORD, LPDWORD)
 KERNEL32.PeekConsoleInputW.restype = wintypes.BOOL
 
 KERNEL32.ReadConsoleInputW.argtypes = (
-    wintypes.HANDLE, _PINPUT_RECORD, wintypes.DWORD, LPDWORD)
+    wintypes.HANDLE, ctypes.POINTER(INPUT_RECORD), wintypes.DWORD, LPDWORD)
 KERNEL32.ReadConsoleInputW.restype = wintypes.BOOL
 
 
@@ -428,97 +449,98 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
     return term
 
 
-def select(fd=None, timeout=None):
-    """
-    Wait for console input to become available.
+class ConsoleInput:
+    """Console input handle with wait, peek, and read operations.
 
     :arg int fd: Python file descriptor (e.g. ``sys.stdin.fileno()``).
-        If ``None``, uses :py:data:`sys.__stdin__`.
-    :arg float timeout: Seconds to wait.  ``None`` blocks indefinitely,
-        ``0`` is non-blocking, positive values specify a deadline.
-    :returns: ``True`` if input is available, ``False`` on timeout.
-    :rtype: bool
-    :raises OSError: If WaitForSingleObject_ fails.
 
-    Analog of :py:func:`select.select` for a Windows console handle.
-    The call is non-destructive -- no events are consumed.
+    Example::
 
-    .. _WaitForSingleObject:
-        https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
+        console = ConsoleInput(sys.stdin.fileno())
+        if console.wait(timeout=5.0):
+            event = console.peek()
     """
-    if fd is None:
-        fd = sys.__stdin__.fileno()
 
-    handle = msvcrt.get_osfhandle(fd)
+    def __init__(self, fd):
+        self._fd = fd
+        self._handle = msvcrt.get_osfhandle(fd)
 
-    if timeout is None:
-        wait_ms = 0xFFFFFFFF  # INFINITE
-    else:
-        wait_ms = int(1000 * max(0, timeout))
+    @property
+    def fd(self):
+        """The Python file descriptor."""
+        return self._fd
 
-    result = KERNEL32.WaitForSingleObject(handle, wait_ms)
+    @property
+    def handle(self):
+        """The Windows console handle."""
+        return self._handle
 
-    if result == 0xFFFFFFFF:  # WAIT_FAILED
-        raise ctypes.WinError(ctypes.get_last_error())
+    def wait(self, timeout=None):
+        """Wait for console input to become available.
 
-    return result == 0x00000000  # WAIT_OBJECT_0
+        :arg float timeout: Seconds to wait.  ``None`` blocks indefinitely,
+            ``0`` is non-blocking, positive values specify a deadline.
+        :returns: ``True`` if input is available, ``False`` on timeout.
+        :rtype: bool
+        :raises OSError: If WaitForSingleObject_ fails.
 
+        The call is non-destructive -- no events are consumed.
 
-def peek_input(fd=None):
-    """
-    Peek at the next console input event without consuming it.
+        .. _WaitForSingleObject:
+            https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
+        """
+        if timeout is None:
+            wait_ms = 0xFFFFFFFF  # INFINITE
+        else:
+            wait_ms = int(1000 * max(0, timeout))
 
-    :arg int fd: Python file descriptor (e.g. ``sys.stdin.fileno()``).
-        If ``None``, uses :py:data:`sys.__stdin__`.
-    :returns: The next :py:class:`_INPUT_RECORD`, or ``None`` if the
-        buffer is empty.
-    :rtype: _INPUT_RECORD or None
-    :raises OSError: If PeekConsoleInputW_ fails.
+        result = KERNEL32.WaitForSingleObject(self._handle, wait_ms)
 
-    .. _PeekConsoleInputW:
-        https://docs.microsoft.com/en-us/windows/console/peekconsoleinput
-    """
-    if fd is None:
-        fd = sys.__stdin__.fileno()
+        if result == 0xFFFFFFFF:  # WAIT_FAILED
+            raise ctypes.WinError(ctypes.get_last_error())
 
-    handle = msvcrt.get_osfhandle(fd)
-    record = _INPUT_RECORD()
-    count = wintypes.DWORD()
+        return result == 0x00000000  # WAIT_OBJECT_0
 
-    if not KERNEL32.PeekConsoleInputW(
-            handle, ctypes.byref(record), 1, ctypes.byref(count)):
-        raise ctypes.WinError(ctypes.get_last_error())
+    def peek(self):
+        """Peek at the next console input event without consuming it.
 
-    if count.value == 0:
-        return None
-    return record
+        :returns: The next :py:class:`INPUT_RECORD`, or ``None`` if the
+            buffer is empty.
+        :rtype: INPUT_RECORD or None
+        :raises OSError: If PeekConsoleInputW_ fails.
 
+        .. _PeekConsoleInputW:
+            https://learn.microsoft.com/en-us/windows/console/peekconsoleinput
+        """
+        record = INPUT_RECORD()
+        count = wintypes.DWORD()
 
-def read_input(fd=None):
-    """
-    Read and consume the next console input event.
+        if not KERNEL32.PeekConsoleInputW(
+                self._handle, ctypes.byref(record), 1, ctypes.byref(count)):
+            raise ctypes.WinError(ctypes.get_last_error())
 
-    :arg int fd: Python file descriptor (e.g. ``sys.stdin.fileno()``).
-        If ``None``, uses :py:data:`sys.__stdin__`.
-    :returns: The next :py:class:`_INPUT_RECORD`, or ``None`` if the
-        buffer is empty.
-    :rtype: _INPUT_RECORD or None
-    :raises OSError: If ReadConsoleInputW_ fails.
+        if count.value == 0:
+            return None
+        return record
 
-    .. _ReadConsoleInputW:
-        https://docs.microsoft.com/en-us/windows/console/readconsoleinput
-    """
-    if fd is None:
-        fd = sys.__stdin__.fileno()
+    def read(self):
+        """Read and consume the next console input event.
 
-    handle = msvcrt.get_osfhandle(fd)
-    record = _INPUT_RECORD()
-    count = wintypes.DWORD()
+        :returns: The next :py:class:`INPUT_RECORD`, or ``None`` if the
+            buffer is empty.
+        :rtype: INPUT_RECORD or None
+        :raises OSError: If ReadConsoleInputW_ fails.
 
-    if not KERNEL32.ReadConsoleInputW(
-            handle, ctypes.byref(record), 1, ctypes.byref(count)):
-        raise ctypes.WinError(ctypes.get_last_error())
+        .. _ReadConsoleInputW:
+            https://learn.microsoft.com/en-us/windows/console/readconsoleinput
+        """
+        record = INPUT_RECORD()
+        count = wintypes.DWORD()
 
-    if count.value == 0:
-        return None
-    return record
+        if not KERNEL32.ReadConsoleInputW(
+                self._handle, ctypes.byref(record), 1, ctypes.byref(count)):
+            raise ctypes.WinError(ctypes.get_last_error())
+
+        if count.value == 0:
+            return None
+        return record

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -469,9 +469,7 @@ def kbhit(fd=None, timeout=None):
         # Calculate remaining wait.
         if deadline is not None:
             remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return False
-            wait_ms = int(1000 * remaining)
+            wait_ms = int(1000 * max(0, remaining))
         else:
             wait_ms = 0xFFFFFFFF  # INFINITE
 

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -106,8 +106,6 @@ KERNEL32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
 KERNEL32.WaitForSingleObject.restype = wintypes.DWORD
 
 # Console input record structures for PeekConsoleInputW/ReadConsoleInputW.
-# Only KEY_EVENT_RECORD is needed -- all other event types (mouse, focus,
-# resize, menu) are drained and discarded by kbhit() for now.
 
 
 class _KEY_EVENT_RECORD(ctypes.Structure):
@@ -130,7 +128,23 @@ class _EVENT_UNION(ctypes.Union):
 
 
 class _INPUT_RECORD(ctypes.Structure):
-    """INPUT_RECORD structure."""
+    """INPUT_RECORD structure.
+
+    .. py:attribute:: EventType
+
+        Event type constant:
+
+        - ``0x0001`` -- KEY_EVENT
+        - ``0x0002`` -- MOUSE_EVENT
+        - ``0x0004`` -- WINDOW_BUFFER_SIZE_EVENT
+        - ``0x0008`` -- MENU_EVENT
+        - ``0x0010`` -- FOCUS_EVENT
+
+    .. py:attribute:: Event
+
+        Union containing the event data. Access ``Event.KeyEvent``
+        for key events.
+    """
 
     _fields_ = [
         ('EventType', wintypes.WORD),
@@ -139,6 +153,12 @@ class _INPUT_RECORD(ctypes.Structure):
 
 
 _PINPUT_RECORD = ctypes.POINTER(_INPUT_RECORD)
+
+KEY_EVENT = 0x0001
+MOUSE_EVENT = 0x0002
+WINDOW_BUFFER_SIZE_EVENT = 0x0004
+MENU_EVENT = 0x0008
+FOCUS_EVENT = 0x0010
 
 KERNEL32.PeekConsoleInputW.argtypes = (
     wintypes.HANDLE, _PINPUT_RECORD, wintypes.DWORD, LPDWORD)
@@ -408,49 +428,20 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
     return term
 
 
-def _drain_nonkey_events(handle):
+def select(fd=None, timeout=None):
     """
-    Discard non-key-down events from the console input buffer.
+    Wait for console input to become available.
 
-    :arg int handle: Windows console handle.
-    :returns: True if a key-down event is at the front of the buffer.
+    :arg int fd: Python file descriptor (e.g. ``sys.stdin.fileno()``).
+        If ``None``, uses :py:data:`sys.__stdin__`.
+    :arg float timeout: Seconds to wait.  ``None`` blocks indefinitely,
+        ``0`` is non-blocking, positive values specify a deadline.
+    :returns: ``True`` if input is available, ``False`` on timeout.
     :rtype: bool
-    """
-    record = _INPUT_RECORD()
-    count = wintypes.DWORD()
-    while True:
-        if not KERNEL32.PeekConsoleInputW(
-                handle, ctypes.byref(record), 1, ctypes.byref(count)):
-            return False
-        if count.value == 0:
-            return False
-        if record.EventType == 0x0001 and record.Event.KeyEvent.bKeyDown:
-            return True  # KEY_EVENT with bKeyDown
-        # discard non-key-down event (key-up, focus, mouse, resize, menu)
-        if not KERNEL32.ReadConsoleInputW(
-                handle, ctypes.byref(record), 1, ctypes.byref(count)):
-            return False
+    :raises OSError: If WaitForSingleObject_ fails.
 
-
-def kbhit(fd=None, timeout=None):
-    """
-    Args:
-        fd(int): Python file descriptor for keyboard input (e.g., sys.stdin.fileno()).
-            If None, uses the file descriptor of :py:data:`sys.__stdin__`.
-        timeout(float): Timeout in seconds. None for blocking indefinitely,
-            0 for non-blocking, positive for seconds to wait.
-
-    Returns:
-        bool: True if a keypress is available to be read, False otherwise.
-
-    Raises:
-        OSError: If WaitForSingleObject fails
-
-    Efficient keyboard hit detection using WaitForSingleObject_.
-
-    After the wait signals, non-keyboard events (key-up releases, focus,
-    resize) are drained from the input buffer so that only actual key-down
-    events cause a True return.
+    Analog of :py:func:`select.select` for a Windows console handle.
+    The call is non-destructive -- no events are consumed.
 
     .. _WaitForSingleObject:
         https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
@@ -459,24 +450,75 @@ def kbhit(fd=None, timeout=None):
         fd = sys.__stdin__.fileno()
 
     handle = msvcrt.get_osfhandle(fd)
-    deadline = None if timeout is None else time.monotonic() + max(0, timeout)
 
-    while True:
-        # Drain stale non-key events, return immediately if key-down ready.
-        if _drain_nonkey_events(handle):
-            return True
+    if timeout is None:
+        wait_ms = 0xFFFFFFFF  # INFINITE
+    else:
+        wait_ms = int(1000 * max(0, timeout))
 
-        # Calculate remaining wait.
-        if deadline is not None:
-            remaining = deadline - time.monotonic()
-            wait_ms = int(1000 * max(0, remaining))
-        else:
-            wait_ms = 0xFFFFFFFF  # INFINITE
+    result = KERNEL32.WaitForSingleObject(handle, wait_ms)
 
-        result = KERNEL32.WaitForSingleObject(handle, wait_ms)
+    if result == 0xFFFFFFFF:  # WAIT_FAILED
+        raise ctypes.WinError(ctypes.get_last_error())
 
-        if result == 0xFFFFFFFF:  # WAIT_FAILED
-            raise ctypes.WinError(ctypes.get_last_error())
+    return result == 0x00000000  # WAIT_OBJECT_0
 
-        if result != 0x00000000:  # WAIT_TIMEOUT
-            return False
+
+def peek_input(fd=None):
+    """
+    Peek at the next console input event without consuming it.
+
+    :arg int fd: Python file descriptor (e.g. ``sys.stdin.fileno()``).
+        If ``None``, uses :py:data:`sys.__stdin__`.
+    :returns: The next :py:class:`_INPUT_RECORD`, or ``None`` if the
+        buffer is empty.
+    :rtype: _INPUT_RECORD or None
+    :raises OSError: If PeekConsoleInputW_ fails.
+
+    .. _PeekConsoleInputW:
+        https://docs.microsoft.com/en-us/windows/console/peekconsoleinput
+    """
+    if fd is None:
+        fd = sys.__stdin__.fileno()
+
+    handle = msvcrt.get_osfhandle(fd)
+    record = _INPUT_RECORD()
+    count = wintypes.DWORD()
+
+    if not KERNEL32.PeekConsoleInputW(
+            handle, ctypes.byref(record), 1, ctypes.byref(count)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    if count.value == 0:
+        return None
+    return record
+
+
+def read_input(fd=None):
+    """
+    Read and consume the next console input event.
+
+    :arg int fd: Python file descriptor (e.g. ``sys.stdin.fileno()``).
+        If ``None``, uses :py:data:`sys.__stdin__`.
+    :returns: The next :py:class:`_INPUT_RECORD`, or ``None`` if the
+        buffer is empty.
+    :rtype: _INPUT_RECORD or None
+    :raises OSError: If ReadConsoleInputW_ fails.
+
+    .. _ReadConsoleInputW:
+        https://docs.microsoft.com/en-us/windows/console/readconsoleinput
+    """
+    if fd is None:
+        fd = sys.__stdin__.fileno()
+
+    handle = msvcrt.get_osfhandle(fd)
+    record = _INPUT_RECORD()
+    count = wintypes.DWORD()
+
+    if not KERNEL32.ReadConsoleInputW(
+            handle, ctypes.byref(record), 1, ctypes.byref(count)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    if count.value == 0:
+        return None
+    return record

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -47,6 +47,11 @@ ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 DISABLE_NEWLINE_AUTO_RETURN = 0x0008
 ENABLE_LVB_GRID_WORLDWIDE = 0x0010
 
+# WaitForSingleObject return values and constants
+WAIT_OBJECT_0 = 0x00000000
+WAIT_TIMEOUT = 0x00000102
+INFINITE = 0xFFFFFFFF
+
 if IS_WINDOWS and tuple(int(num) for num in platform.version().split('.')) >= (10, 0, 10586):
     VTMODE_SUPPORTED = True
     CBREAK_MODE = ENABLE_PROCESSED_INPUT | ENABLE_VIRTUAL_TERMINAL_INPUT
@@ -100,6 +105,9 @@ KERNEL32.SetConsoleMode.argtypes = (wintypes.HANDLE, wintypes.DWORD)
 
 KERNEL32.GetConsoleScreenBufferInfo.errcheck = _check_bool
 KERNEL32.GetConsoleScreenBufferInfo.argtypes = (wintypes.HANDLE, CSBIP)
+
+KERNEL32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+KERNEL32.WaitForSingleObject.restype = wintypes.DWORD
 
 
 def get_csbi(filehandle=None):
@@ -359,3 +367,21 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
             term = 'unknown'
 
     return term
+
+
+def wait_for_single_object(handle, timeout_ms):
+    """
+    Args:
+        handle(int): Windows handle object as returned by :py:func:`msvcrt.get_osfhandle`
+        timeout_ms(int): Timeout in milliseconds, or INFINITE for no timeout
+
+    Returns:
+        int: WAIT_OBJECT_0 if signaled, WAIT_TIMEOUT if timed out, or other wait result
+
+    Wrapper for WaitForSingleObject_
+
+    .. _WaitForSingleObject:
+        https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject
+    """
+
+    return KERNEL32.WaitForSingleObject(handle, timeout_ms)


### PR DESCRIPTION
Adds a commit addressing feedback from #6,

I will also add a commit to prepare it for release

## Summary by Sourcery

Add Windows keyboard hit detection using WaitForSingleObject for efficient console input polling.

New Features:
- Introduce a win32.kbhit helper that waits for keyboard input using WaitForSingleObject with optional timeouts.

Enhancements:
- Expose and configure the Win32 WaitForSingleObject API in the Windows console helper module.