### PR TITLE
replace 2 rst code with direct link for README.rst

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -59,7 +59,7 @@ Introduction
 
 Jinxed is a pure-Python implementation of a subset of the Python curses_ library.
 
-It provides :py:func:`~jinxed.tigetstr`, :py:func:`~jinxed.tparm`, and related terminfo
+It provides `jinxed.tigetstr()`, `jinxed.tparm()`, and related terminfo
 functions on all platforms with a virtual `terminfo(5)`_ database.
 
 Jinxed provides pure-python implementations of curses_ functions:


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Revise intro.rst to change the reference to the README from inlined reStructuredText code to a direct link.