### PR TITLE
Workaround RTD 'stable' build isn't updating

### DIFF
--- a/doc/capabilities.rst
+++ b/doc/capabilities.rst
@@ -158,7 +158,7 @@ Three kinds of Control Codes **are** removed from the virtual database:
   Jinxed provides no functions to manage historic character sets and so they are removed.
 
 .. _curses: https://docs.python.org/3/library/curses.html
-.. _jinxed.terminal: https://jinxed.readthedocs.io/en/stable/api.html#jinxed.terminal
+.. _jinxed.terminal: https://jinxed.readthedocs.io/en/latest/api.html#jinxed.terminal
 .. _`terminfo(5)`: https://invisible-island.net/ncurses/man/terminfo.5.html
 .. _terminfo.src: https://invisible-island.net/ncurses/terminfo.src.html
 .. _`terminfo/`: https://github.com/Rockhopper-Technologies/jinxed/tree/main/jinxed/terminfo

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -75,7 +75,7 @@ Although Jinxed was created primarily to be a dependency to supply Windows suppo
 since been extended to contain a subset of the ncurses 6.6 `terminfo(5)`_ database and to allow
 dynamic injection capabilities for `XTGETTCAP`_ support, demonstrated in blessed_ 1.40.
 
-Further documentation can be found on `Read the Docs <https://jinxed.readthedocs.io/en/stable/>`_.
+Further documentation can be found on `Read the Docs <https://jinxed.readthedocs.io/en/latest/>`_.
 
 Installation
 ------------
@@ -97,11 +97,11 @@ Please report issues `on GitHub <https://github.com/Rockhopper-Technologies/jinx
 .. _curses: https://docs.python.org/library/curses.html
 .. _blessed: https://pypi.org/project/blessed
 .. _XTGETTCAP: https://invisible-island.net/xterm/xterm.faq.html#xtgettcap
-.. _`jinxed.setupterm()`: https://jinxed.readthedocs.io/en/stable/api.html#jinxed.setupterm
-.. _`jinxed.tigetflag()`: https://jinxed.readthedocs.io/en/stable/api.html#jinxed.tigetflag
-.. _`jinxed.tigetnum()`: https://jinxed.readthedocs.io/en/stable/api.html#jinxed.tigetnum
-.. _`jinxed.tigetstr()`: https://jinxed.readthedocs.io/en/stable/api.html#jinxed.tigetstr
-.. _`jinxed.tparm()`: https://jinxed.readthedocs.io/en/stable/api.html#jinxed.tparm
+.. _`jinxed.setupterm()`: https://jinxed.readthedocs.io/en/latest/api.html#jinxed.setupterm
+.. _`jinxed.tigetflag()`: https://jinxed.readthedocs.io/en/latest/api.html#jinxed.tigetflag
+.. _`jinxed.tigetnum()`: https://jinxed.readthedocs.io/en/latest/api.html#jinxed.tigetnum
+.. _`jinxed.tigetstr()`: https://jinxed.readthedocs.io/en/latest/api.html#jinxed.tigetstr
+.. _`jinxed.tparm()`: https://jinxed.readthedocs.io/en/latest/api.html#jinxed.tparm
 .. _`setupterm()`: https://docs.python.org/library/curses.html#curses.setupterm
 .. _`terminfo(5)`: https://man7.org/linux/man-pages/man5/terminfo.5.html
 .. _`terminfo.src`: https://invisible-island.net/ncurses/terminfo.src.html


### PR DESCRIPTION
The main page https://jinxed.readthedocs.io/ redirects to show "stable",
https://jinxed.readthedocs.io/en/stable/

Which is copyright 2019-2024, built 1mo ago.

I tagged and released jinxed 1.5.0 to pypi, and it builds ok as "latest" on readthedocs.org, but I'm
not sure how it detects when to publish 'stable'

This can fix our own self-links to point to 'latest', or, some other fix can be made in sphinx
configuration, I don't have the access to see

## Summary by Sourcery

Documentation:
- Adjust documentation pages to link to the "latest" Read the Docs version rather than the "stable" alias for self-referential links.