### PR TITLE
ansicon should ENABLE_VIRTUAL_TERMINAL_PROCESSING

### DIFF
--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -374,7 +374,7 @@ def flush_and_set_console(fd, mode=None):  # pylint:  disable=invalid-name
 
 
 def _ensure_vt_processing(fd):
-    """Enable ENABLE_VIRTUAL_TERMINAL_PROCESSING on *fd*, registering atexit restore.
+    """Enable ENABLE_VIRTUAL_TERMINAL_PROCESSING on *fd*, registering atexit(3) restore.
 
     No-op if the flag is already set.  Raises :class:`OSError` if *fd* cannot be
     interrogated (e.g. it is not a console handle).

--- a/jinxed/win32.py
+++ b/jinxed/win32.py
@@ -373,6 +373,21 @@ def flush_and_set_console(fd, mode=None):  # pylint:  disable=invalid-name
             pass
 
 
+def _ensure_vt_processing(fd):
+    """Enable ENABLE_VIRTUAL_TERMINAL_PROCESSING on *fd*, registering atexit restore.
+
+    No-op if the flag is already set.  Raises :class:`OSError` if *fd* cannot be
+    interrogated (e.g. it is not a console handle).
+    """
+    filehandle = msvcrt.get_osfhandle(fd)
+    mode = get_console_mode(filehandle)
+    if mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING:
+        atexit.register(flush_and_set_console, fd, None)
+    else:
+        atexit.register(flush_and_set_console, fd, mode)
+        set_console_mode(filehandle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+
+
 def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
     """
     Args:
@@ -407,6 +422,11 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
         # See if ansicon is enabled
         if os.environ.get('ANSICON', None):
             term = 'ansicon'
+            if VTMODE_SUPPORTED:
+                try:
+                    _ensure_vt_processing(fd)
+                except OSError:
+                    pass
 
         # See if Windows Terminal is being used Windows Terminal (wt.exe, now Terminal.exe) is a
         # modern host application distinct from the legacy Windows Console Host (conhost.exe).
@@ -420,21 +440,10 @@ def get_term(fd, fallback=True):  # pylint:  disable=invalid-name
         #   https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
         elif VTMODE_SUPPORTED:
             try:
-                filehandle = msvcrt.get_osfhandle(fd)
-                mode = get_console_mode(filehandle)
+                _ensure_vt_processing(fd)
             except OSError:
                 term = 'unknown'
             else:
-                # Proceed if VT mode is already enabled
-                if mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING:
-                    atexit.register(flush_and_set_console, fd, None)
-
-                # Otherwise, enable VT mode
-                else:
-                    atexit.register(flush_and_set_console, fd, mode)
-                    # pylint: disable=unsupported-binary-operation
-                    set_console_mode(filehandle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
-
                 term = 'vtwin10'
 
         # Currently falling back to Ansicon for older versions of Windows

--- a/pylintrc
+++ b/pylintrc
@@ -30,7 +30,7 @@ spelling-private-dict-file=doc/spelling_wordlist.txt
 
 # List of comma separated words that should not be checked.
 spelling-ignore-words=
-    acsc, ansicon, API, args, Avram,
+    acsc, ansicon, API, args, atexit, Avram,
     bool,
     cbreak,
     fd, filehandle,


### PR DESCRIPTION
https://github.com/jquast/blessed/issues/382

A strange effect with ConEmu.exe, when launching programs as a script, XTGETTCAP queries are seen as literal output:

```
$ py -3 bin\display-unicode.py
←P+q544e←\←P+q524742←\←P+q636f6c6f7273←\←P+q626c696e6b←\←P+q7369746d←\←P+q7269746d←\←P+q6376766973←\←P+q536d756c78←\←P+q536574756c63←\←P+q4d73←\Unicode Support Report
======================

- Wide characters supported (v15.0.0)
- Emojis with ZWJ not supported
- Emojis with VS-16 not supported
- Ambiguous width is narrow (1)
- Grapheme clustering (mode 2027): NO
```

This is not visible from a REPL,
```
$ py -3
Python 3.14.3 (tags/v3.14.3:323c59a, Feb  3 2026, 16:04:56) [MSC v.1944 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import blessed
>>> t=blessed.Terminal()
>>> t.get_xtgettcap(force=True)
```

This appears to be caused by ENABLE_VIRTUAL_TERMINAL_PROCESSING, [enabled by python's REPL ](https://github.com/python/cpython/blob/fad06746051f6bd95a255d49e38ebf049e965109/Lib/_pyrepl/windows_console.py#L175-L177)