### PR TITLE
remove pycache files from sdist package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,7 @@ include LICENSE* setup_helpers.py README.*
 graft doc
 graft tests
 include terminals.toml
+
+global-exclude __pycache__
+global-exclude *.pyc
+global-exclude *.pyo


### PR DESCRIPTION
when building jinxed-2.1.0 for pypi release and checking file contents, i was surprised to see the
``__pycache__`` folder and contents, this is from "graft tests" in MANIFEST.in, which includes
everything:

    jinxed-2.1.0/tests/__pycache__/
    jinxed-2.1.0/tests/__pycache__/__init__.cpython-313.pyc
    jinxed-2.1.0/tests/__pycache__/__init__.cpython-314.pyc
    jinxed-2.1.0/tests/__pycache__/test_terminal.cpython-313.pyc
    jinxed-2.1.0/tests/__pycache__/test_terminal.cpython-314-pytest-9.0.3.pyc
    jinxed-2.1.0/tests/__pycache__/test_terminal.cpython-314.pyc
    jinxed-2.1.0/tests/__pycache__/test_terminfo.cpython-313.pyc
    jinxed-2.1.0/tests/__pycache__/test_terminfo.cpython-314.pyc
    jinxed-2.1.0/tests/__pycache__/test_tparm.cpython-313.pyc
    jinxed-2.1.0/tests/__pycache__/test_tparm.cpython-314.pyc

These kinds of ``tests/__pycache__/`` and ``.pyc`` and pypy files have been in every past jinxed
sdist release except for 1.4.0 and this most recent one, 2.1.0 where it was noticed and manually
removed before publishing.

Added global-exclude for pycache files to MANIFEST.in to prevent it.

## Summary by Sourcery

Build:
- Add a global exclude rule in MANIFEST.in to omit __pycache__ directories and .pyc files from the sdist package.